### PR TITLE
Changed 'class' label to 'species' in Iris

### DIFF
--- a/datasets/iris.csv
+++ b/datasets/iris.csv
@@ -1,4 +1,4 @@
-sepal length (cm),sepal width (cm),petal length (cm),petal width (cm),class
+sepal length (cm),sepal width (cm),petal length (cm),petal width (cm),species
 5.1,3.5,1.4,0.2,setosa
 4.9,3.0,1.4,0.2,setosa
 4.7,3.2,1.3,0.2,setosa


### PR DESCRIPTION
The label 'class' in the Iris dataset is confusing when being used and should be changed. 